### PR TITLE
Add Fix for Local DNS Resolution

### DIFF
--- a/docs/guides/OpenStack Setup Guide.md
+++ b/docs/guides/OpenStack Setup Guide.md
@@ -29,6 +29,37 @@
    
    - If you don't already have the new Windows Terminal, download it from [https://aka.ms/terminal](https://aka.ms/terminal).
 
+   <details>
+      <summary>Fix for Custom DNS Users</summary><br>
+      <span>If you run your own local DNS and you cannot resolve horizon.hackucf.cloud with nslookup, then you will need to add the following to your Records.</span></br></br>
+      <span>DNS Records:</span>
+      <table>
+         <tr>
+            <th>Domain</th>
+            <th>IP Address</th>
+         </tr>
+         <tr>
+            <td>cloud.hackucf</td>
+            <td>10.4.4.10</td>
+         </tr>
+      </table>
+      <span>CNAME Records:</span>
+      <table>
+         <tr>
+            <th>FQDN</th>
+            <th>Domain</th>
+         </tr>
+         <tr>
+            <td>horizon.hackucf.cloud</td>
+            <td>cloud.hackucf</td>
+         </tr>
+         <tr>
+            <td>api.hackucf.cloud</td>
+            <td>cloud.hackucf</td>
+         </tr>
+      </table>
+   </details>
+
 ## Step 3: Create SSH Key
 
 1. Open a terminal.

--- a/docs/guides/OpenStack Setup Guide.md
+++ b/docs/guides/OpenStack Setup Guide.md
@@ -29,37 +29,6 @@
    
    - If you don't already have the new Windows Terminal, download it from [https://aka.ms/terminal](https://aka.ms/terminal).
 
-   <details>
-      <summary>Fix for Custom DNS Users</summary><br>
-      <span>If you run your own local DNS and you cannot resolve horizon.hackucf.cloud with nslookup, then you will need to add the following to your Records.</span></br></br>
-      <span>DNS Records:</span>
-      <table>
-         <tr>
-            <th>Domain</th>
-            <th>IP Address</th>
-         </tr>
-         <tr>
-            <td>cloud.hackucf</td>
-            <td>10.4.4.10</td>
-         </tr>
-      </table>
-      <span>CNAME Records:</span>
-      <table>
-         <tr>
-            <th>FQDN</th>
-            <th>Domain</th>
-         </tr>
-         <tr>
-            <td>horizon.hackucf.cloud</td>
-            <td>cloud.hackucf</td>
-         </tr>
-         <tr>
-            <td>api.hackucf.cloud</td>
-            <td>cloud.hackucf</td>
-         </tr>
-      </table>
-   </details>
-
 ## Step 3: Create SSH Key
 
 1. Open a terminal.

--- a/docs/guides/OpenStack Setup Guide.md
+++ b/docs/guides/OpenStack Setup Guide.md
@@ -11,7 +11,7 @@
 1. Go to [https://openvpn.net/client/](https://openvpn.net/client/).
 2. Download the appropriate version of OpenVPN for your operating system and install it.
    
-   ### For Windows:
+### For Windows:
    
    - Press the Windows key and search for OpenVPN.
    - Run OpenVPN.
@@ -25,7 +25,7 @@
    - Press "Connect".
    - In the future, navigate to the OpenVPN client and select the on switch labeled "vpn.hackucf.org".
    
-   ### For Windows 10 Users:
+### For Windows 10 Users:
    
    - If you don't already have the new Windows Terminal, download it from [https://aka.ms/terminal](https://aka.ms/terminal).
 

--- a/docs/guides/Troubleshooting.md
+++ b/docs/guides/Troubleshooting.md
@@ -1,0 +1,35 @@
+# Troubleshooting
+
+This page provides methods for troubleshooting problems the end user may run into.
+
+## Hackucf DNS records not resolving:
+   <details>
+      <summary>Fix for Custom DNS Users</summary><br>
+      <span>If you run your own local DNS and you cannot resolve horizon.hackucf.cloud with nslookup, then you will need to add the following to your Records.</span></br></br>
+      <span>DNS Records:</span>
+      <table>
+         <tr>
+            <th>Domain</th>
+            <th>IP Address</th>
+         </tr>
+         <tr>
+            <td>cloud.hackucf</td>
+            <td>10.4.4.10</td>
+         </tr>
+      </table>
+      <span>CNAME Records:</span>
+      <table>
+         <tr>
+            <th>FQDN</th>
+            <th>Domain</th>
+         </tr>
+         <tr>
+            <td>horizon.hackucf.cloud</td>
+            <td>cloud.hackucf</td>
+         </tr>
+         <tr>
+            <td>api.hackucf.cloud</td>
+            <td>cloud.hackucf</td>
+         </tr>
+      </table>
+   </details>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,5 +47,6 @@ nav:
       - "Security Groups Guide": "guides/Security Groups.md"
       - "How to Launch an Instance": "guides/How to Launch an Instance.md"
       - "Migration Guide": "guides/Migrate Instance.md"
+      - "Troubleshooting": "guides/Troubleshooting.md"
 #extra_css:
 #  - stylesheets/extra.css


### PR DESCRIPTION
Some Local DNS solutions will not allow FQDN's that point to an IP in the private address space. 
This can be circumvented by adding specific records to the hosts file on the DNS server.